### PR TITLE
added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+eln-cache


### PR DESCRIPTION
Emacs 28 built with `native-comp` branch (aka GccEmacs) creates `eln-cache` directory to house `*.eln` files which are natively compiled versions of `*.elc` files.