### PR TITLE
Allow .emacs-profiles.el in $XDG_CONFIG_HOME/chemacs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add support for early-init.el
 - Change installation from `~/.emacs` to `~/.emacs.d`
+- Allow .emacs-profiles and .emacs-profile to be stored in $XDG\_CONFIG\_HOME/chemacs
 
 # 1.0 (2020-10-01 / 4dad0684)
 

--- a/README.org
+++ b/README.org
@@ -197,7 +197,7 @@ Please refer to [[https://github.com/plexus/chemacs/issues/5][this]] discussion 
 
 ** FreeDesktop Directories
 
-Both =~/.emacs-profiles.el= and =~/.emacs-profile= can also be stored under =$XDG\_CONFIG\_HOME/chemacs= (typically =~/.config/chemacs=) as =$XGD\_CONFIG\_HOME/chemacs/profiles.el= and =$XDG\_CONFIG\_HOME/chemacs/profile= respectively.
+Both =~/.emacs-profiles.el= and =~/.emacs-profile= can also be stored under =$XDG_CONFIG_HOME/chemacs= (typically =~/.config/chemacs=) as =$XGD_CONFIG_HOME/chemacs/profiles.el= and =$XDG_CONFIG_HOME/chemacs/profile= respectively.
 
 ** LICENSE
 

--- a/README.org
+++ b/README.org
@@ -195,6 +195,10 @@ In the following snippet =~/doom-emacs= is where you have cloned doom emacs.
 
 Please refer to [[https://github.com/plexus/chemacs/issues/5][this]] discussion for details.
 
+** FreeDesktop Directories
+
+Both =~/.emacs-profiles.el= and =~/.emacs-profile= can also be stored under =$XDG\_CONFIG\_HOME/chemacs= (typically =~/.config/chemacs=) as =$XGD\_CONFIG\_HOME/chemacs/profiles.el= and =$XDG\_CONFIG\_HOME/chemacs/profile= respectively.
+
 ** LICENSE
 
 Copyright © Arne Brasseur 2018-2020

--- a/chemacs.el
+++ b/chemacs.el
@@ -27,8 +27,12 @@
 
 ;;; Code:
 (defvar chemacs-version "2.0")
-(defvar chemacs-profiles-path "~/.emacs-profiles.el")
-(defvar chemacs-default-profile-path "~/.emacs-profile")
+(defvar config-home (or (getenv "XDG_CONFIG_HOME") "~/.config"))
+(defvar chemacs-profiles-paths (list "~/.emacs-profiles.el" (format "%s/%s" config-home "chemacs/profiles.el" )))
+(defvar chemacs-default-profile-paths (list "~/.emacs-profile" (format "%s/%s" config-home "profile")))
+
+(defvar chemacs-profiles-path (or (car (seq-filter 'file-exists-p chemacs-profiles-paths)) (car chemacs-profiles-paths)))
+(defvar chemacs-default-profile-path (or (car (seq-filter 'file-exists-p chemacs-profiles-paths)) (car chemacs-profiles-paths)))
 
 (when (not (file-exists-p chemacs-profiles-path))
   (error "[chemacs] %s does not exist." chemacs-profiles-path))


### PR DESCRIPTION
Since emacs-27.1 allows it's config to reside in $XDG_CONFIG_HOME/emacs I would like to keep my profiles in $XDG_CONFIG_HOME/chemacs.

Please note that this is my first time working with emacs-lisp so any feedback would be appreciated.