### PR TITLE
Enable the loading a profile via CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add support for early-init.el
 - Change installation from `~/.emacs` to `~/.emacs.d`
 - Allow .emacs-profiles and .emacs-profile to be stored in $XDG\_CONFIG\_HOME/chemacs
+- Allow loading a literal profile from the cli (e.g. `emacs --with-profile '((user-emacs-directory . "/path/to/config"))'` works)
 
 # 1.0 (2020-10-01 / 4dad0684)
 

--- a/README.org
+++ b/README.org
@@ -95,6 +95,12 @@ If no profile is given at the command line then the =default= profile is used.
 $ emacs --with-profile my-profile
 #+END_SRC
 
+There is an option for using profile that is not preconfigured in =~/.emacs-profiles.el=. To accomplish that you can directly provide the profile via the command line, like so
+#+BEGIN_SRC shell
+$ emacs --with-profile '((user-emacs-directory . "/path/to/config"))'
+#+END_SRC
+This method supports all the profile options given below.
+
 ** .emacs-profiles.el
 
 This file contains an association list, with the keys/cars being the profile


### PR DESCRIPTION
Currently a profile must first be specified in `~/.emacs-profiles.el`
in order to be used. In most day-to-day usage this is adequate, but
on occasion it is nice to have a 'throw-away' profile. The rationale
for such a profile is trying someone else's config out for a day / hour
or some such, but it's not something you're committed to.

This change enables the following to work:
```bash
emacs --with-profile '((user-emacs-directory . "/tmp/throw-away-config"))'
```

I originally was going to add this to version 1, but was asked to add it to version 2, so here we are (original [PR](https://github.com/plexus/chemacs/pull/45) I opened)