### PR TITLE
Allow specifying the profile name via a CHEMACS_PROFILE environment variable.

### DIFF
--- a/README.org
+++ b/README.org
@@ -99,7 +99,9 @@ below.
 Chemacs adds an extra command line option to Emacs, =--with-profile=. Profiles
 are configured in =~/.emacs-profiles.el=.
 
-If no profile is given at the command line then the =default= profile is used.
+If no profile is given at the command line then the environment variable
+CHEMACS_PROFILE is used. If this environment variables isn't set then the
+=default= profile is used.
 
 #+BEGIN_SRC shell
 $ emacs --with-profile my-profile
@@ -146,8 +148,9 @@ for a helpful script to do that.
 
 ** Changing the default profile (e.g. for GUI editors)
 
-Where it is not possible to use the =--with-profile= flag, the default profile
-can be set using a =~/.emacs-profile= file.
+Where it is not possible to use the =--with-profile= flag or the CHEMACS_PROFILE
+environment variable, the default profile can be set using a =~/.emacs-profile=
+file.
 
 If your =~/.emacs-profiles.el= file contains the following:
 

--- a/chemacs.el
+++ b/chemacs.el
@@ -30,6 +30,7 @@
 (defvar config-home (or (getenv "XDG_CONFIG_HOME") "~/.config"))
 (defvar chemacs-profiles-paths (list "~/.emacs-profiles.el" (format "%s/%s" config-home "chemacs/profiles.el" )))
 (defvar chemacs-default-profile-paths (list "~/.emacs-profile" (format "%s/%s" config-home "chemacs/profile")))
+(defvar chemacs-profile-env-var "CHEMACS_PROFILE")
 
 ;; Copy `seq' library's `seq-filter' to avoid requiring it, see note above.
 (defun chemacs--seq-filter (pred sequence)
@@ -95,10 +96,12 @@
 
 
 (defvar chemacs-profile-name
-  (if (and chemacs--with-profile-value
-           (stringp chemacs--with-profile-value))
-      chemacs--with-profile-value
-    chemacs-default-profile-name))
+  (let ((env-profile-value (getenv chemacs-profile-env-var)))
+    (cond ((and chemacs--with-profile-value
+                (stringp chemacs--with-profile-value))
+           chemacs--with-profile-value)
+          (env-profile-value env-profile-value)
+          (t chemacs-default-profile-name))))
 
 (defvar chemacs-profile
   (if (and chemacs--with-profile-value


### PR DESCRIPTION
Provide another method to specify the Chemacs profile by specifying an environment variable. 

Among other things, this makes it easier to define shell aliases such as:

```
 alias doom='CHEMACS_PROFILE=doom ~/code/doom-emacs/bin/doom'
```