### PR TITLE
documents short-term fix for straight.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -254,6 +254,7 @@ emacsclient -c -s doom -a emacs
 ** Troubleshooting
 
 *** Emacs cannot find packages installed by straight
+Some users have [[https://github.com/plexus/chemacs2/issues/31][reported issues]] where packages installed by `straight.el` can no longer be found after switching to using `chemacs`.
 
 First, make sure you haven't hardcoded filepaths to "emacs.d" in your configuration. You should reference files inside a profile-specific emacs folder like this:
 

--- a/README.org
+++ b/README.org
@@ -251,6 +251,20 @@ emacsclient -c -s gnu -a emacs
 emacsclient -c -s doom -a emacs
 #+end_src
 
+** Troubleshooting
+
+*** Emacs cannot find packages installed by straight
+
+First, make sure you haven't hardcoded filepaths to "emacs.d" in your configuration. You should reference files inside a profile-specific emacs folder like this:
+
+#+begin_src elisp
+(setq some-var (expand-file-name "path/to/file" user-emacs-directory))
+#+END_SRC
+
+Second, if the issue persists you should delete the `build` folder in your `straight` directory and rebuild your dependencies.
+
+If the issue persists please file an issue because we are still trying to figure out the exact source of this problem, but this has solved the problem for some users.
+
 ** LICENSE
 
 Copyright © Arne Brasseur 2018-2020


### PR DESCRIPTION
Users who switch to chemacs from a non-chemacs configuration might
encounter #31. This does not constitute a long-term fix but this might
help users in the meantime until further debugging is done.