### PR TITLE
Add support for environment variables in profiles.el

### DIFF
--- a/chemacs.el
+++ b/chemacs.el
@@ -129,7 +129,7 @@ selected profile (if any)."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (setq user-emacs-directory (file-name-as-directory
-                            (chemacs-profile-get 'user-emacs-directory)))
+                            (substitute-in-file-name (chemacs-profile-get 'user-emacs-directory))))
 
 ;; Allow multiple profiles to each run their server
 ;; use `emacsclient -s profile_name' to connect
@@ -139,7 +139,7 @@ selected profile (if any)."
 ;; Set environment variables, these are visible to init-file with
 ;; getenv
 (mapcar (lambda (env)
-          (setenv (car env) (cdr env)))
+          (setenv (car env) (substitute-in-file-name (cdr env))))
         (chemacs-profile-get 'env))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/early-init.el
+++ b/early-init.el
@@ -1,5 +1,6 @@
 ;;; early-init.el --- -*- lexical-binding: t; -*-
 
+(add-to-list 'default-frame-alist '(undecorated-round . t))
 (require 'chemacs
          (expand-file-name "chemacs.el"
                            (file-name-directory


### PR DESCRIPTION
This change adds support for using environment variables in the emacs profiles defined in profiles.el.

e.g. this allows a user to specify profile install locations to comply with XDG specfication:
```
(
 ("spacemacs" . (
                 (user-emacs-directory . "$XDG_CONFIG_HOME/emacs-spacemacs/")
                 (env . (("SPACEMACSDIR" . "$XDG_CONFIG_HOME/spacemacs/")))
                 )
  )
 ("doom" . (
            (user-emacs-directory . "$XDG_CONFIG_HOME/emacs-doom")
            )
  )
 )
```