### PR TITLE
Set `packge-user-dir` in early-init.el

### DIFF
--- a/chemacs.el
+++ b/chemacs.el
@@ -146,6 +146,7 @@ selected profile (if any)."
 
 (defun chemacs-load-user-early-init ()
   (let ((early-init-file (expand-file-name "early-init.el" user-emacs-directory)))
+    (setq package-user-dir (expand-file-name "elpa" user-emacs-directory))
     (load early-init-file t t)))
 
 (defun chemacs-load-user-init ()


### PR DESCRIPTION
In Emacs 27 and later `package-initialize` is called automatically after `early-init.el` but before `init.el`. This change allows that call to actually work with the user's packages. I left the assignment in the init code for Emacs versions less than 27 that don't support `early-init.el`.