### PR TITLE
Support specifying a nix-generated elisp package bundle

### DIFF
--- a/README.org
+++ b/README.org
@@ -140,6 +140,14 @@ Other things you can configure
   visible to any subprocesses spawned from Emacs.
 - =straight-p= Enable the [[https://github.com/raxod502/straight.el][Straight]]
   functional package manager.
+- =nix-elisp-bundle= A directory containing elisp dependencies bundled by the
+  nix package manager. The bundle path can be produced by nix using an
+  expression like =(emacs.pkgs.withPackages (p: [ p.avy … ])).deps=.
+  Because the bundle path is in the nix store, if it is specified
+  in =.emacs-profiles.el= then that file should also be maintained by
+  nix, to prevent the path from being garbage-collected.
+  Alternatively, a nix-generated script or alias could specify
+  =nix-elisp-bundle= as a command-line argument.
 
 Store =.emacs-profiles.el= together with your dotfiles. If you're not yet keeping
 a version controlled directory of dotfiles, then check out

--- a/chemacs.el
+++ b/chemacs.el
@@ -142,6 +142,23 @@ selected profile (if any)."
           (setenv (car env) (cdr env)))
         (chemacs-profile-get 'env))
 
+;; Insinuate a nix elisp dependency bundle, if specified. In Emacs 27, the
+;; startup.el looks through the load-path for any directory named site-lisp with
+;; a subdirectory named elpa. If found, it activates them as packages. Starting
+;; in Emacs 28, it instead relies on package-directory-list. It seems we can
+;; distinguish these by whether package-directory-list is already bound in
+;; early-init.
+(let ((dir (chemacs-profile-get 'nix-elisp-bundle)))
+  (when dir
+    (if (boundp 'package-directory-list)
+	(add-to-list 'package-directory-list
+		     (concat dir "/share/emacs/site-lisp/elpa"))
+      (add-to-list 'load-path
+		   (concat dir "/share/emacs/site-lisp")))
+    (when (boundp 'native-comp-eln-load-path)
+      (add-to-list 'native-comp-eln-load-path
+		   (concat dir "/share/emacs/native-lisp/")))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defun chemacs-load-user-early-init ()

--- a/chemacs.el
+++ b/chemacs.el
@@ -152,12 +152,12 @@ selected profile (if any)."
   (when dir
     (if (boundp 'package-directory-list)
 	(add-to-list 'package-directory-list
-		     (concat dir "/share/emacs/site-lisp/elpa"))
+		     (expand-file-name "share/emacs/site-lisp/elpa" dir))
       (add-to-list 'load-path
-		   (concat dir "/share/emacs/site-lisp")))
+		   (expand-file-name "share/emacs/site-lisp" dir)))
     (when (boundp 'native-comp-eln-load-path)
       (add-to-list 'native-comp-eln-load-path
-		   (concat dir "/share/emacs/native-lisp/")))))
+		   (expand-file-name "share/emacs/native-lisp/" dir)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 


### PR DESCRIPTION
The nix package manager supports a flexible way to bundle sets of Emacs packages, including ahead-of-time native compilation.  This change provides a simple mechanism for insinuating a nix elisp dependency bundle using chemacs, so that different nix package sets can be selected using `--with-profile`, along-side profiles using other package managers or distributions like Spacemacs/Doom.